### PR TITLE
Support both plymouth-set-default-theme and update-alternatives

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -148,8 +148,12 @@ else
     chmod +x ./pv_conf.sh
 fi
 
-if [[ -z "$(command -v plymouth-set-default-theme)" ]]; then
-    echo "Plymouth-scripts package is not installed! Stopping."
+if command -v plymouth-set-default-theme >/dev/null 2>&1; then
+    USE_LEGACY=1
+elif command -v update-alternatives >/dev/null 2>&1; then
+    USE_LEGACY=0
+else
+    echo "No supported Plymouth theme manager found."
     exit 2
 fi
 
@@ -158,7 +162,15 @@ if [[ ! -f $COMPILED_SCRIPT ]]; then
     exit 1
 fi
 
-if plymouth-set-default-theme --list | grep -qe "PlymouthVista" || [ -d $INSTALL_DIR ]; then
+if [[ $USE_LEGACY == 1 ]]; then
+    plymouth-set-default-theme --list 2>/dev/null | grep -q "PlymouthVista"
+    INSTALLED=$?
+else
+    update-alternatives --display default.plymouth 2>/dev/null | grep -q "PlymouthVista"
+    INSTALLED=$?
+fi
+
+if [[ $INSTALLED -eq 0 ]] || [ -d "$INSTALL_DIR" ]; then
     if [[ $OVERWRITE == 0 ]]; then
         read -p "PlymouthVista is already installed, Do you want to overwrite it? (y/N): " ANSWER
         if [[ $ANSWER == "${ANSWER#[Yy]}" ]]; then
@@ -304,6 +316,20 @@ fi
 
 if [[ $NO_APPLY == 0 ]]; then
     echo "Setting plymouth theme as default..."
-    plymouth-set-default-theme -R PlymouthVista
+
+    if [[ $USE_LEGACY == 1 ]]; then
+        plymouth-set-default-theme -R PlymouthVista
+    else
+        update-alternatives --install \
+            /usr/share/plymouth/themes/default.plymouth \
+            default.plymouth \
+            /usr/share/plymouth/themes/PlymouthVista/PlymouthVista.plymouth 200
+
+        update-alternatives --set default.plymouth \
+            /usr/share/plymouth/themes/PlymouthVista/PlymouthVista.plymouth
+
+        update-initramfs -u
+    fi
 fi
+
 echo "Done."

--- a/install.sh
+++ b/install.sh
@@ -149,9 +149,9 @@ else
 fi
 
 if command -v plymouth-set-default-theme >/dev/null 2>&1; then
-    USE_LEGACY=1
+    DEBIAN_INSTALL=0
 elif command -v update-alternatives >/dev/null 2>&1; then
-    USE_LEGACY=0
+    DEBIAN_INSTALL=1
 else
     echo "No supported Plymouth theme manager found."
     exit 2
@@ -162,7 +162,7 @@ if [[ ! -f $COMPILED_SCRIPT ]]; then
     exit 1
 fi
 
-if [[ $USE_LEGACY == 1 ]]; then
+if [[ $DEBIAN_INSTALL == 0 ]]; then
     plymouth-set-default-theme --list 2>/dev/null | grep -q "PlymouthVista"
     INSTALLED=$?
 else
@@ -317,7 +317,7 @@ fi
 if [[ $NO_APPLY == 0 ]]; then
     echo "Setting plymouth theme as default..."
 
-    if [[ $USE_LEGACY == 1 ]]; then
+    if [[ $DEBIAN_INSTALL == 0 ]]; then
         plymouth-set-default-theme -R PlymouthVista
     else
         update-alternatives --install \


### PR DESCRIPTION
## Summary

This PR updates the installer to support both legacy systems using
`plymouth-set-default-theme` and newer Ubuntu releases that use
`update-alternatives`.

## Changes

- Detects whether `plymouth-set-default-theme` or `update-alternatives` is available.
- Preserves compatibility with older systems.
- Uses `update-alternatives` on newer Ubuntu releases.
- Updates the initramfs after changing the default Plymouth theme.

## Motivation

On newer Ubuntu releases, `plymouth-set-default-theme` is no longer
available by default, causing the installer to stop even though Plymouth
is installed. This change allows the installer to work on both legacy and
modern systems.